### PR TITLE
Fix crash in destroyToken hook when token has no swarmMesh

### DIFF
--- a/scripts/swarm.mjs
+++ b/scripts/swarm.mjs
@@ -1330,7 +1330,7 @@ Hooks.on(
 		}
 		token.swarm?.destroy();
 		// Restore original's swarm mesh if this was a config dialog preview
-		if (token._original?.swarmMesh?.parent !== canvas.primary) {
+		if (token._original?.swarmMesh && token._original.swarmMesh.parent !== canvas.primary) {
 			canvas.primary.addChild(token._original.swarmMesh);
 		}
 	}


### PR DESCRIPTION
## Summary
- Fix `TypeError: Cannot read properties of undefined (reading 'parent')` in `swarmsDestroyToken` hook
- The optional chain `token._original?.swarmMesh?.parent` returns `undefined` when `swarmMesh` is absent, which is `!== canvas.primary`, so `addChild(undefined)` is called and throws
- Added an explicit truthy check on `swarmMesh` before comparing its parent

## Test plan
- [ ] Place a non-swarm token, drag it to trigger `destroyToken` — no error
- [ ] Open a swarm token's config dialog, confirm preview cleanup still restores the mesh

🤖 Generated with [Claude Code](https://claude.com/claude-code)