### PR TITLE
Allow players to edit swarm properties on owned tokens

### DIFF
--- a/scripts/ui.mjs
+++ b/scripts/ui.mjs
@@ -114,7 +114,8 @@ function createCheckBox({ app, parent, data_name, title, hint }) {
 }
 
 const swarmsRenderConfig = (objectName) => (app, html, data, options) => {
-	if (!game.user.isGM) return;
+	const token = app.token ?? app.document;
+	if (!token?.isOwner) return;
 
 	const doc = app.element?.ownerDocument || document;
 


### PR DESCRIPTION
## Summary
- Replace the GM-only gate (`game.user.isGM`) in the token/tile config UI with an ownership check (`isOwner`)
- Players can now configure swarm settings (enabled, count, speed, animation) on tokens for actors they own
- GMs retain full access since they have ownership of all documents

Closes #40

## Test plan
- [ ] As GM, verify swarm config still appears on token and tile config sheets
- [ ] As a player, open the config for an owned token — swarm fieldset should appear
- [ ] As a player, open the config for an unowned token — swarm fieldset should not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)