### PR TITLE
Fix swarm sprites invisible on tokens with 0 max HP

### DIFF
--- a/scripts/swarm.mjs
+++ b/scripts/swarm.mjs
@@ -242,16 +242,12 @@ export class Swarm {
 
 		this.tick = new PIXI.Ticker();
 		this._animType = document.getFlag(MOD_NAME, ANIM_TYPE_FLAG) ?? DEFAULT_ANIMATION;
-		this._textureSrc = this.useRandomImage ? null : this._getTextureSrc();
+		this._textureSrc = this.useRandomImage ? null : document.texture.src;
 		this._swarmSpeed = document.getFlag(MOD_NAME, SWARM_SPEED_FLAG) ?? DEFAULT_SWARM_SPEED;
 		this._applyAnimationType(this._animType);
 		this.tick.add(this.anim.bind(this));
 		this.tick.start();
 		Hooks.call("createSwarm", this);
-	}
-
-	_getTextureSrc() {
-		return this.document.texture?.src || CONST.DEFAULT_TOKEN;
 	}
 
 	_applyAnimationType(anim) {
@@ -341,7 +337,7 @@ export class Swarm {
 		if (this.useRandomImage) {
 			images = await swarm_socket.executeAsGM("wildcards", this.object.id);
 		} else {
-			images.push(this._getTextureSrc());
+			images.push(this.document.texture.src);
 		}
 
 		const anim = this.document.getFlag(MOD_NAME, ANIM_TYPE_FLAG) ?? DEFAULT_ANIMATION;
@@ -734,7 +730,7 @@ export class Swarm {
 		const newSize = this.document.getFlag(MOD_NAME, SWARM_SIZE_FLAG) ?? DEFAULT_SWARM_SIZE;
 		const newAnim = this.document.getFlag(MOD_NAME, ANIM_TYPE_FLAG) ?? DEFAULT_ANIMATION;
 		const newSpeed = this.document.getFlag(MOD_NAME, SWARM_SPEED_FLAG) ?? DEFAULT_SWARM_SPEED;
-		const newTextureSrc = this._getTextureSrc();
+		const newTextureSrc = this.document.texture.src;
 
 		const sizeChanged = newSize !== this.maxSprites;
 		const animChanged = newAnim !== this._animType;

--- a/scripts/swarm.mjs
+++ b/scripts/swarm.mjs
@@ -95,7 +95,7 @@ function getHealthEstimate(token) {
 				case "D35E":
 				case "wfrp4e":
 				default:
-					return hpValue / hpMax;
+					return hpMax === 0 ? 1 : hpValue / hpMax;
 				case "swade":
 					return hpMax === 0 ? 1 : Math.max(hpMax - hpValue, 0) / Math.max(hpMax, 1);
 			}
@@ -242,12 +242,16 @@ export class Swarm {
 
 		this.tick = new PIXI.Ticker();
 		this._animType = document.getFlag(MOD_NAME, ANIM_TYPE_FLAG) ?? DEFAULT_ANIMATION;
-		this._textureSrc = this.useRandomImage ? null : document.texture.src;
+		this._textureSrc = this.useRandomImage ? null : this._getTextureSrc();
 		this._swarmSpeed = document.getFlag(MOD_NAME, SWARM_SPEED_FLAG) ?? DEFAULT_SWARM_SPEED;
 		this._applyAnimationType(this._animType);
 		this.tick.add(this.anim.bind(this));
 		this.tick.start();
 		Hooks.call("createSwarm", this);
+	}
+
+	_getTextureSrc() {
+		return this.document.texture?.src || CONST.DEFAULT_TOKEN;
 	}
 
 	_applyAnimationType(anim) {
@@ -337,7 +341,7 @@ export class Swarm {
 		if (this.useRandomImage) {
 			images = await swarm_socket.executeAsGM("wildcards", this.object.id);
 		} else {
-			images.push(this.document.texture.src);
+			images.push(this._getTextureSrc());
 		}
 
 		const anim = this.document.getFlag(MOD_NAME, ANIM_TYPE_FLAG) ?? DEFAULT_ANIMATION;
@@ -730,7 +734,7 @@ export class Swarm {
 		const newSize = this.document.getFlag(MOD_NAME, SWARM_SIZE_FLAG) ?? DEFAULT_SWARM_SIZE;
 		const newAnim = this.document.getFlag(MOD_NAME, ANIM_TYPE_FLAG) ?? DEFAULT_ANIMATION;
 		const newSpeed = this.document.getFlag(MOD_NAME, SWARM_SPEED_FLAG) ?? DEFAULT_SWARM_SPEED;
-		const newTextureSrc = this.document.texture.src;
+		const newTextureSrc = this._getTextureSrc();
 
 		const sizeChanged = newSize !== this.maxSprites;
 		const animChanged = newAnim !== this._animType;


### PR DESCRIPTION
## Summary
- Guard against division by zero in `getHealthEstimate` when an actor's max HP is 0 (e.g. unconfigured actors) — `0 / 0` produced `NaN` which propagated through `determineVisibleSprites` → `this.number` → `this.visible`, causing all sprites to stay at alpha 0

## Test plan
- [ ] Create a token from an actor with 0/0 HP and enable swarm — sprites should be visible at full count
- [ ] Verify existing swarm tokens with configured HP still scale sprite count correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)