### PR TITLE
Fix combat turn marker rendering on top of swarm sprites

### DIFF
--- a/scripts/swarm.mjs
+++ b/scripts/swarm.mjs
@@ -151,6 +151,25 @@ class SwarmMesh extends PrimarySpriteMesh {
 		// Base Sprite shouldn't be rendered
 	}
 
+	// Foundry's Token#voidMesh calls mesh._renderVoid each frame to "punch out" the
+	// token's shape from the interface buffer so the combat turn marker shows only as
+	// a halo around the token. Our base sprite renders nothing, so without this the
+	// turn marker would cover the swarm sprites instead of sitting behind them.
+	_renderVoid(renderer) {
+		if (!this.visible || this.worldAlpha <= 0 || !this.renderable) return;
+		if (!this.object?.turnMarker) return;
+		const children = this.children;
+		for (let i = 0; i < children.length; i++) {
+			const sprite = children[i];
+			if (!(sprite instanceof PIXI.Sprite)) continue;
+			if (!sprite.visible || sprite.alpha <= 0 || !sprite.renderable) continue;
+			const originalBlendMode = sprite.blendMode;
+			sprite.blendMode = PIXI.BLEND_MODES.ERASE;
+			sprite._render(renderer);
+			sprite.blendMode = originalBlendMode;
+		}
+	}
+
 	// Override rotation and angle
 	// Swarms can't face a direction (except formSquare, but this is handled by the Swarm)
 	get rotation() {


### PR DESCRIPTION
## Summary
- Combat turn marker was covering swarm sprites instead of appearing as a halo around them.
- Foundry's `Token#voidMesh` calls `mesh._renderVoid` each frame with `BLEND_MODES.ERASE` to punch the token's shape out of the interface buffer (where the turn marker is drawn). Because `SwarmMesh._render` is a no-op, the inherited `_renderVoid` erased nothing — leaving the marker fully on top.
- Override `_renderVoid` on `SwarmMesh` to iterate visible sprite children and render each with `ERASE` blend, so the marker sits behind the swarm. Bails early when no `turnMarker` is active to avoid the per-frame cost.
Fixes #50 

## Test plan
- [ ] Load a swarm token into combat and confirm the turn marker now sits *behind* the swarm sprites (visible only around them).
- [ ] Verify a non-swarm token still renders the turn marker as before.
- [ ] Verify hidden / faded swarms still behave correctly when their token has the active turn.
- [ ] Verify performance is unchanged outside of combat (no active turn marker on the token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)